### PR TITLE
Update MLAT Tag to latest

### DIFF
--- a/radarbox/Dockerfile.template
+++ b/radarbox/Dockerfile.template
@@ -19,7 +19,7 @@ RUN apt update && \
 
 FROM base AS buildstep
 
-ARG MLAT_TAG=v0.3.9
+ARG MLAT_TAG=v0.4.2
 ARG TEMP_INSTALL="build-essential debhelper python3-dev git" 
 
 RUN apt update && \


### PR DESCRIPTION
From 0.3.9 to 0.4.2 (https://github.com/adsbxchange/mlat-client/tags).  This will also match the mlat container.