### PR TITLE
fix(wingbits): make Renovate update all digest variants together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,11 +22,10 @@
       "managerFilePatterns": [
         "/(^|/)wingbits/Dockerfile\\.template$/"
       ],
-      "matchStringsStrategy": "combination",
       "matchStrings": [
-        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\n",
-        "ENV WINGBITS_DATE=(?<currentDigest>.*?)\\n"
+        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\nENV WINGBITS_DATE=(?<currentDigest>.*?)\\n"
       ],
+      "autoReplaceStringTemplate": "ENV WINGBITS_COMMIT_ID={{{newValue}}}\nENV WINGBITS_DATE={{{newDigest}}}\n",
       "depNameTemplate": "wingbits-meta",
       "datasourceTemplate": "custom.wingbits-meta"
     },
@@ -35,11 +34,10 @@
       "managerFilePatterns": [
         "/(^|/)wingbits/Dockerfile\\.template$/"
       ],
-      "matchStringsStrategy": "combination",
       "matchStrings": [
-        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\n",
-        "ENV WINGBITS_SHA256_AMD64=(?<currentDigest>.*?)\\n"
+        "# wingbits-rev (?<currentValue>.*?)\\nENV WINGBITS_SHA256_AMD64=(?<currentDigest>.*?)\\n"
       ],
+      "autoReplaceStringTemplate": "# wingbits-rev {{{newValue}}}\nENV WINGBITS_SHA256_AMD64={{{newDigest}}}\n",
       "depNameTemplate": "wingbits-binary-amd64",
       "packageNameTemplate": "amd64",
       "datasourceTemplate": "custom.wingbits-binary"
@@ -49,11 +47,10 @@
       "managerFilePatterns": [
         "/(^|/)wingbits/Dockerfile\\.template$/"
       ],
-      "matchStringsStrategy": "combination",
       "matchStrings": [
-        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\n",
-        "ENV WINGBITS_SHA256_ARM64=(?<currentDigest>.*?)\\n"
+        "# wingbits-rev (?<currentValue>.*?)\\nENV WINGBITS_SHA256_ARM64=(?<currentDigest>.*?)\\n"
       ],
+      "autoReplaceStringTemplate": "# wingbits-rev {{{newValue}}}\nENV WINGBITS_SHA256_ARM64={{{newDigest}}}\n",
       "depNameTemplate": "wingbits-binary-arm64",
       "packageNameTemplate": "arm64",
       "datasourceTemplate": "custom.wingbits-binary"
@@ -63,11 +60,10 @@
       "managerFilePatterns": [
         "/(^|/)wingbits/Dockerfile\\.template$/"
       ],
-      "matchStringsStrategy": "combination",
       "matchStrings": [
-        "ENV WINGBITS_COMMIT_ID=(?<currentValue>.*?)\\n",
-        "ENV WINGBITS_SHA256_ARM=(?<currentDigest>.*?)\\n"
+        "# wingbits-rev (?<currentValue>.*?)\\nENV WINGBITS_SHA256_ARM=(?<currentDigest>.*?)\\n"
       ],
+      "autoReplaceStringTemplate": "# wingbits-rev {{{newValue}}}\nENV WINGBITS_SHA256_ARM={{{newDigest}}}\n",
       "depNameTemplate": "wingbits-binary-arm",
       "packageNameTemplate": "arm",
       "datasourceTemplate": "custom.wingbits-binary"

--- a/wingbits/Dockerfile.template
+++ b/wingbits/Dockerfile.template
@@ -12,17 +12,22 @@ ENV RECEIVER_PORT=30005
 # tracked by the wingbits-version custom manager in renovate.json.
 ENV WINGBITS_CONFIG_VERSION=0.2.1
 # WINGBITS_COMMIT_ID, WINGBITS_DATE and the per-arch SHA256 hashes
-# below are managed by Renovate. Each line is paired with
-# WINGBITS_COMMIT_ID via a combination-strategy regex manager keyed
-# off custom.wingbits-meta / custom.wingbits-binary, so the binary
-# URL and the verified checksum always refer to the same upstream
-# release. The SHA256 values are the base64 Sha256 strings from
-# install.wingbits.com/linux-<arch>.json — Renovate returns them
-# verbatim and the installer decodes them at build time.
+# below are managed by Renovate. Each value is paired with the
+# upstream release version on the same (or an adjacent "# wingbits-rev")
+# line so that Renovate's regex manager rewrites the version and the
+# digest together in a single replaceString — see the wingbits-meta /
+# wingbits-binary custom managers in renovate.json. The SHA256 values
+# are the base64 Sha256 strings from install.wingbits.com/linux-<arch>.json
+# — Renovate returns them verbatim and the installer decodes them at
+# build time. Keep the "# wingbits-rev" markers in sync with
+# WINGBITS_COMMIT_ID; Renovate does this automatically on update.
 ENV WINGBITS_COMMIT_ID=v1.12.0
 ENV WINGBITS_DATE=2026-05-12T13:27:03.248603202Z
+# wingbits-rev v1.12.0
 ENV WINGBITS_SHA256_AMD64=IJxqhEFAgnlMmnHv+kA3muQW9f98RVHTZrjvuAV8L3g=
+# wingbits-rev v1.12.0
 ENV WINGBITS_SHA256_ARM64=/rE+0E4nJMVvATDjccj5HxwGU1dmyW7d9wh/VerTFDI=
+# wingbits-rev v1.12.0
 ENV WINGBITS_SHA256_ARM=3Jv/zlPKVR8jShmR1RO1Rs9rgU5VqPArnztMQZ0cFwo=
 
 ARG PERM_INSTALL="curl ca-certificates gettext-base tini ncurses-dev zlib1g jq python3-pip python3-venv wget"


### PR DESCRIPTION
## Problem

Renovate fails to update the wingbits SHA256 digests on a version bump. On the live dry-run (`v1.12.0` → `v1.12.1`) it aborts with:

```
"replaceString":"ENV WINGBITS_SHA256_AMD64=...\n","currentValue":"v1.12.0",
   "msg":"currentValue not found in string to replace"
→ "Error updating branch: update failure"
```

## Root cause

The four wingbits managers used `matchStringsStrategy: "combination"` with `currentValue` (`WINGBITS_COMMIT_ID`) and `currentDigest` on **separate lines**. In combination mode Renovate sets the dependency's `replaceString` to the **last** matchString match — the digest line — which contains no version string. On a version bump Renovate tries to substitute the new version into `replaceString`, can't find the old version there, and aborts the whole grouped branch, so none of the SHA digests update (same defect as ketilmo/balena-ads-b#557).

## Fix

Each manager now uses a **single** matchString capturing version + digest from two adjacent lines, so `replaceString` spans both and holds the version Renovate needs to rewrite. An explicit `autoReplaceStringTemplate` rewrites version and digest together. The three SHA lines get an adjacent `# wingbits-rev <version>` anchor (they carry no version of their own); `wingbits-meta` keeps `COMMIT_ID` + `DATE` as its adjacent pair. Renovate keeps the markers in sync automatically.

Passes `renovate-config-validator --strict`.

## Validation

After merge, tick the "manual job" box on the Dependency Dashboard to re-run Renovate and confirm the `wingbits version to latest` branch updates DATE + all three SHAs in one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)