### PR TITLE
fix(wingbits): silence spurious digest-lookup warning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -239,6 +239,15 @@
       "separateMajorMinor": false,
       "separateMinorPatch": false,
       "separateMultipleMajor": false
+    },
+    {
+      "matchDatasources": [
+        "custom.wingbits-meta",
+        "custom.wingbits-binary"
+      ],
+      "digest": {
+        "enabled": false
+      }
     }
   ],
   "logLevelRemap": [


### PR DESCRIPTION
## Goal

Clear the residual `⚠️ Package lookup failures` repo problem (`Could not determine new digest for update`) that remained after #26, so the wingbits Renovate setup is clean before upstreaming.

## Why the warning happens

Two independent paths:
- **SHA write (works):** the version bump `v1.12.0 → v1.12.1` is a `patch` update whose `newDigest` comes from the release's `digest` field the custom datasource returns (`$.Sha256` / `$.Date`) — *not* from `getDigest()`.
- **Warning (harmless):** because `currentDigest` is set, Renovate separately probes `getDigest()` to refresh the *current* version's digest. Custom datasources don't implement `getDigest`, so it returns null and warns — every run, even when up to date.

## Fix

```json
{
  "matchDatasources": ["custom.wingbits-meta", "custom.wingbits-binary"],
  "digest": { "enabled": false }
}
```

This gates the current-version digest-refresh path (the `getDigest()` probe), so the warning is never produced. The version-bump `newDigest` is sourced from the release object on a different path, so all four arch/meta values still update together.

Passes `renovate-config-validator --strict`.

## Validation

After merge, tick the "manual job" box on the Dependency Dashboard. Expected:
- `repoProblems` no longer lists `Package lookup failures`
- the `wingbits version to latest` branch still updates DATE + all three SHAs (re-confirms #26 behaviour is intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)