### PR TITLE
Revert inert digest packageRule (#28)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -239,15 +239,6 @@
       "separateMajorMinor": false,
       "separateMinorPatch": false,
       "separateMultipleMajor": false
-    },
-    {
-      "matchDatasources": [
-        "custom.wingbits-meta",
-        "custom.wingbits-binary"
-      ],
-      "digest": {
-        "enabled": false
-      }
     }
   ],
   "logLevelRemap": [


### PR DESCRIPTION
Reverts the `digest: { enabled: false }` packageRule added in #28.

The re-run after #28 confirmed it has **no effect**: the `getDigest()` probe runs during lookup and records `Could not determine new digest for update` into the dependency *before* packageRules filter the update, so the warning (and the `Package lookup failures` repo problem) persisted unchanged.

Removing it so the config doesn't carry a rule that implies behaviour it doesn't deliver. The warning is a benign, pre-existing artifact of `currentDigest` + a custom datasource (no `getDigest` implementation); version-bump digests come from the release object, so updates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)